### PR TITLE
Fix lib name for windows build

### DIFF
--- a/recipe/libfile-link-to-zimg-dll.patch
+++ b/recipe/libfile-link-to-zimg-dll.patch
@@ -1,0 +1,10 @@
+diff --git a/_msvc/zimg.def b/_msvc/zimg.def
+index e1b9443..1aef9bc 100644
+--- a/_msvc/zimg.def
++++ b/_msvc/zimg.def
+@@ -1,4 +1,4 @@
+-LIBRARY z
++LIBRARY zimg
+ EXPORTS
+ 	zimg_get_version_info
+ 	zimg_get_api_version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://github.com/sekrit-twc/zimg/archive/release-{{ version }}.tar.gz
   sha256: 219d1bc6b7fde1355d72c9b406ebd730a4aed9c21da779660f0a4c851243e32f
+  patches:
+    - libfile-link-to-zimg-dll.patch  # [win]
 
 build:
-  number: 3
+  number: 4
   run_exports:
     - {{ pin_subpackage('zimg', min_pin='x.x', max_pin='x.x') }}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Fixes #6.
